### PR TITLE
Additional to concatenated string, return array of objects from component

### DIFF
--- a/addon/components/expression-builder.js
+++ b/addon/components/expression-builder.js
@@ -25,11 +25,8 @@ export default Ember.Component.extend({
       return `${type}${value}${operator}`
     })
     let exp = kv.join(' ');
-    if(exp && Ember.get(this, 'expressionChangedCriterion')) {
-      Ember.get(this, 'expressionChangedCriterion')(exp);
-    }
-    if(blocks && Ember.get(this, 'expressionChangedBlock')) {
-      Ember.get(this, 'expressionChangedBlock')(blocks);
+    if(exp && Ember.get(this, 'expressionChanged')) {
+      Ember.get(this, 'expressionChanged')(exp, blocks);
     }
     return exp;
   }),

--- a/addon/components/expression-builder.js
+++ b/addon/components/expression-builder.js
@@ -25,10 +25,21 @@ export default Ember.Component.extend({
       return `${type}${value}${operator}`
     })
     let exp = kv.join(' ');
-    if(exp && Ember.get(this, 'expressionChanged')) {
-      Ember.get(this, 'expressionChanged')(exp);
+    if(blocks && Ember.get(this, 'expressionChanged')) {
+      Ember.get(this, 'expressionChanged')(blocks);
     }
     return exp;
+  }),
+
+  expressionOutput(output) {
+    if(output && Ember.get(this, 'expressionChanged')) {
+      Ember.get(this, 'expressionChanged')(output);
+    }
+  },
+
+  ledgerArray: Ember.computed('blocks.@each.{id,type,value,operator}', function() {
+    this.expressionOutput(Ember.get(this, 'blocks'))
+    return Ember.get(this, 'blocks');
   }),
 
   init() {

--- a/addon/components/expression-builder.js
+++ b/addon/components/expression-builder.js
@@ -25,21 +25,13 @@ export default Ember.Component.extend({
       return `${type}${value}${operator}`
     })
     let exp = kv.join(' ');
-    if(blocks && Ember.get(this, 'expressionChanged')) {
-      Ember.get(this, 'expressionChanged')(blocks);
+    if(exp && Ember.get(this, 'expressionChangedCriterion')) {
+      Ember.get(this, 'expressionChangedCriterion')(exp);
+    }
+    if(blocks && Ember.get(this, 'expressionChangedBlock')) {
+      Ember.get(this, 'expressionChangedBlock')(blocks);
     }
     return exp;
-  }),
-
-  expressionOutput(output) {
-    if(output && Ember.get(this, 'expressionChanged')) {
-      Ember.get(this, 'expressionChanged')(output);
-    }
-  },
-
-  ledgerArray: Ember.computed('blocks.@each.{id,type,value,operator}', function() {
-    this.expressionOutput(Ember.get(this, 'blocks'))
-    return Ember.get(this, 'blocks');
   }),
 
   init() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expression-builder",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Build expressions with a GUI",
   "keywords": [
     "ember-addon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expression-builder",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "Build expressions with a GUI",
   "keywords": [
     "ember-addon",

--- a/tests/integration/components/expression-builder-test.js
+++ b/tests/integration/components/expression-builder-test.js
@@ -110,7 +110,7 @@ test('does not have expression if showExpression is false', function(assert) {
   assert.notOk(this.$('.expression-result').text().trim().length);
 });
 
-test('expressionChanged fired and returns arg1 when expression changes', function(assert) {
+test('expressionChanged fired when expression changes', function(assert) {
   this.set('options', {'x': [1], 'y': [2, 3]});
   var exp = null;
   this.set('expressionChanged', (expression) => {exp=expression});
@@ -120,7 +120,7 @@ test('expressionChanged fired and returns arg1 when expression changes', functio
   assert.equal(exp, 'y');
 });
 
-test('expressionChanged fired and returns arg1 when expression changes even if showExpression is false', function(assert) {
+test('expressionChanged fired when expression changes even if showExpression is false', function(assert) {
   this.set('options', {'x': [1], 'y': [2, 3]});
   var exp = null;
   this.set('expressionChanged', (expression) => {exp=expression});
@@ -130,7 +130,7 @@ test('expressionChanged fired and returns arg1 when expression changes even if s
   assert.equal(exp, 'y');
 });
 
-test('expressionChanged only fired and returns arg1 when expression is something', function(assert) {
+test('expressionChanged only fired when expression is something', function(assert) {
   this.set('options', {'x': [1], 'y': [2, 3]});
   var exp = 'previous value';
   this.set('expressionChanged', (expression) => {exp=expression});
@@ -141,7 +141,7 @@ test('expressionChanged only fired and returns arg1 when expression is something
   assert.equal(exp, 'y');
 });
 
-test('expressionChanged fired and returns arg2 when expression changes', function(assert) {
+test('expressionChanged fired and returns blocks object when expression changes', function(assert) {
   this.set('options', {'x': [1], 'y': [2, 3]});
   var exp = null;
   this.set('expressionChanged', (expression, blocks) => {exp=JSON.stringify(blocks)});
@@ -151,7 +151,7 @@ test('expressionChanged fired and returns arg2 when expression changes', functio
   assert.ok(exp.indexOf('"type":"y"') >= 0);
 });
 
-test('expressionChanged fired and returns arg2 when expression changes even if showExpression is false', function(assert) {
+test('expressionChanged fired and returns blocks object when expression changes even if showExpression is false', function(assert) {
   this.set('options', {'x': [1], 'y': [2, 3]});
   var exp = null;
   this.set('expressionChanged', (expression, blocks) => {exp=JSON.stringify(blocks)});
@@ -161,7 +161,7 @@ test('expressionChanged fired and returns arg2 when expression changes even if s
   assert.ok(exp.indexOf('"type":"y"') >= 0);
 });
 
-test('expressionChanged only fired and returns arg2 when expression is something', function(assert) {
+test('expressionChanged only fired and returns blocks object when expression is something', function(assert) {
   this.set('options', {'x': [1], 'y': [2, 3]});
   var exp = 'previous value';
   this.set('expressionChanged', (expression, blocks) => {exp=JSON.stringify(blocks)});

--- a/tests/integration/components/expression-builder-test.js
+++ b/tests/integration/components/expression-builder-test.js
@@ -117,7 +117,7 @@ test('expressionChanged fired when expression changes', function(assert) {
   this.render(hbs`{{expression-builder options=options expressionChanged=expressionChanged}}`);
   this.$('.block-type option[value="y"]').prop('selected', true).trigger('change');
   assert.equal(this.$('.block-type select > option:selected').text().trim(), 'y');
-  assert.equal(exp, 'y');
+  assert.equal(exp, '[object Object]');
 });
 
 test('expressionChanged fired when expression changes even if showExpression is false', function(assert) {
@@ -127,7 +127,7 @@ test('expressionChanged fired when expression changes even if showExpression is 
   this.render(hbs`{{expression-builder options=options expressionChanged=expressionChanged showExpression=false}}`);
   this.$('.block-type option[value="y"]').prop('selected', true).trigger('change');
   assert.equal(this.$('.block-type select > option:selected').text().trim(), 'y');
-  assert.equal(exp, 'y');
+  assert.equal(exp, '[object Object]');
 });
 
 test('expressionChanged only fired when expression is something', function(assert) {
@@ -135,10 +135,10 @@ test('expressionChanged only fired when expression is something', function(asser
   var exp = 'previous value';
   this.set('expressionChanged', (expression) => {exp=expression});
   this.render(hbs`{{expression-builder options=options expressionChanged=expressionChanged showExpression=false}}`);
-  assert.equal(exp, 'previous value');
+  assert.equal(exp, '[object Object]');
   this.$('.block-type option[value="y"]').prop('selected', true).trigger('change');
   assert.equal(this.$('.block-type select > option:selected').text().trim(), 'y');
-  assert.equal(exp, 'y');
+  assert.equal(exp, '[object Object]');
 });
 
 test('can select a different index from the value', function(assert) {

--- a/tests/integration/components/expression-builder-test.js
+++ b/tests/integration/components/expression-builder-test.js
@@ -110,63 +110,63 @@ test('does not have expression if showExpression is false', function(assert) {
   assert.notOk(this.$('.expression-result').text().trim().length);
 });
 
-test('expressionChangedCriterion fired when expression changes', function(assert) {
+test('expressionChanged fired and returns arg1 when expression changes', function(assert) {
   this.set('options', {'x': [1], 'y': [2, 3]});
   var exp = null;
-  this.set('expressionChangedCriterion', (expression) => {exp=expression});
-  this.render(hbs`{{expression-builder options=options expressionChangedCriterion=expressionChangedCriterion}}`);
+  this.set('expressionChanged', (expression) => {exp=expression});
+  this.render(hbs`{{expression-builder options=options expressionChanged=expressionChanged}}`);
   this.$('.block-type option[value="y"]').prop('selected', true).trigger('change');
   assert.equal(this.$('.block-type select > option:selected').text().trim(), 'y');
   assert.equal(exp, 'y');
 });
 
-test('expressionChangedCriterion fired when expression changes even if showExpression is false', function(assert) {
+test('expressionChanged fired and returns arg1 when expression changes even if showExpression is false', function(assert) {
   this.set('options', {'x': [1], 'y': [2, 3]});
   var exp = null;
-  this.set('expressionChangedCriterion', (expression) => {exp=expression});
-  this.render(hbs`{{expression-builder options=options expressionChangedCriterion=expressionChangedCriterion showExpression=false}}`);
+  this.set('expressionChanged', (expression) => {exp=expression});
+  this.render(hbs`{{expression-builder options=options expressionChanged=expressionChanged showExpression=false}}`);
   this.$('.block-type option[value="y"]').prop('selected', true).trigger('change');
   assert.equal(this.$('.block-type select > option:selected').text().trim(), 'y');
   assert.equal(exp, 'y');
 });
 
-test('expressionChangedCriterion only fired when expression is something', function(assert) {
+test('expressionChanged only fired and returns arg1 when expression is something', function(assert) {
   this.set('options', {'x': [1], 'y': [2, 3]});
   var exp = 'previous value';
-  this.set('expressionChangedCriterion', (expression) => {exp=expression});
-  this.render(hbs`{{expression-builder options=options expressionChangedCriterion=expressionChangedCriterion showExpression=false}}`);
+  this.set('expressionChanged', (expression) => {exp=expression});
+  this.render(hbs`{{expression-builder options=options expressionChanged=expressionChanged showExpression=false}}`);
   assert.equal(exp, 'previous value');
   this.$('.block-type option[value="y"]').prop('selected', true).trigger('change');
   assert.equal(this.$('.block-type select > option:selected').text().trim(), 'y');
   assert.equal(exp, 'y');
 });
 
-test('expressionChangedBlock fired when expression changes', function(assert) {
+test('expressionChanged fired and returns arg2 when expression changes', function(assert) {
   this.set('options', {'x': [1], 'y': [2, 3]});
   var exp = null;
-  this.set('expressionChangedBlock', (expression) => {exp=expression});
-  this.render(hbs`{{expression-builder options=options expressionChangedBlock=expressionChangedBlock}}`);
+  this.set('expressionChanged', (expression, blocks) => {exp=blocks});
+  this.render(hbs`{{expression-builder options=options expressionChanged=expressionChanged}}`);
   this.$('.block-type option[value="y"]').prop('selected', true).trigger('change');
   assert.equal(this.$('.block-type select > option:selected').text().trim(), 'y');
   assert.equal(exp, '[object Object]');
 });
 
-test('expressionChangedBlock fired when expression changes even if showExpression is false', function(assert) {
+test('expressionChanged fired and returns arg2 when expression changes even if showExpression is false', function(assert) {
   this.set('options', {'x': [1], 'y': [2, 3]});
   var exp = null;
-  this.set('expressionChangedBlock', (expression) => {exp=expression});
-  this.render(hbs`{{expression-builder options=options expressionChangedBlock=expressionChangedBlock showExpression=false}}`);
+  this.set('expressionChanged', (expression, blocks) => {exp=blocks});
+  this.render(hbs`{{expression-builder options=options expressionChanged=expressionChanged showExpression=false}}`);
   this.$('.block-type option[value="y"]').prop('selected', true).trigger('change');
   assert.equal(this.$('.block-type select > option:selected').text().trim(), 'y');
   assert.equal(exp, '[object Object]');
 });
 
-test('expressionChangedBlock only fired when expression is something', function(assert) {
+test('expressionChanged only fired and returns arg2 when expression is something', function(assert) {
   this.set('options', {'x': [1], 'y': [2, 3]});
   var exp = 'previous value';
-  this.set('expressionChangedBlock', (expression) => {exp=expression});
-  this.render(hbs`{{expression-builder options=options expressionChangedBlock=expressionChangedBlock showExpression=false}}`);
-  assert.equal(exp, '[object Object]');
+  this.set('expressionChanged', (expression, blocks) => {exp=blocks});
+  this.render(hbs`{{expression-builder options=options expressionChanged=expressionChanged showExpression=false}}`);
+  assert.equal(exp, 'previous value');
   this.$('.block-type option[value="y"]').prop('selected', true).trigger('change');
   assert.equal(this.$('.block-type select > option:selected').text().trim(), 'y');
   assert.equal(exp, '[object Object]');

--- a/tests/integration/components/expression-builder-test.js
+++ b/tests/integration/components/expression-builder-test.js
@@ -110,31 +110,62 @@ test('does not have expression if showExpression is false', function(assert) {
   assert.notOk(this.$('.expression-result').text().trim().length);
 });
 
-test('expressionChanged fired when expression changes', function(assert) {
+test('expressionChangedCriterion fired when expression changes', function(assert) {
   this.set('options', {'x': [1], 'y': [2, 3]});
   var exp = null;
-  this.set('expressionChanged', (expression) => {exp=expression});
-  this.render(hbs`{{expression-builder options=options expressionChanged=expressionChanged}}`);
+  this.set('expressionChangedCriterion', (expression) => {exp=expression});
+  this.render(hbs`{{expression-builder options=options expressionChangedCriterion=expressionChangedCriterion}}`);
   this.$('.block-type option[value="y"]').prop('selected', true).trigger('change');
   assert.equal(this.$('.block-type select > option:selected').text().trim(), 'y');
-  assert.equal(exp, '[object Object]');
+  assert.equal(exp, 'y');
 });
 
-test('expressionChanged fired when expression changes even if showExpression is false', function(assert) {
+test('expressionChangedCriterion fired when expression changes even if showExpression is false', function(assert) {
   this.set('options', {'x': [1], 'y': [2, 3]});
   var exp = null;
-  this.set('expressionChanged', (expression) => {exp=expression});
-  this.render(hbs`{{expression-builder options=options expressionChanged=expressionChanged showExpression=false}}`);
+  this.set('expressionChangedCriterion', (expression) => {exp=expression});
+  this.render(hbs`{{expression-builder options=options expressionChangedCriterion=expressionChangedCriterion showExpression=false}}`);
   this.$('.block-type option[value="y"]').prop('selected', true).trigger('change');
   assert.equal(this.$('.block-type select > option:selected').text().trim(), 'y');
-  assert.equal(exp, '[object Object]');
+  assert.equal(exp, 'y');
 });
 
-test('expressionChanged only fired when expression is something', function(assert) {
+test('expressionChangedCriterion only fired when expression is something', function(assert) {
   this.set('options', {'x': [1], 'y': [2, 3]});
   var exp = 'previous value';
-  this.set('expressionChanged', (expression) => {exp=expression});
-  this.render(hbs`{{expression-builder options=options expressionChanged=expressionChanged showExpression=false}}`);
+  this.set('expressionChangedCriterion', (expression) => {exp=expression});
+  this.render(hbs`{{expression-builder options=options expressionChangedCriterion=expressionChangedCriterion showExpression=false}}`);
+  assert.equal(exp, 'previous value');
+  this.$('.block-type option[value="y"]').prop('selected', true).trigger('change');
+  assert.equal(this.$('.block-type select > option:selected').text().trim(), 'y');
+  assert.equal(exp, 'y');
+});
+
+test('expressionChangedBlock fired when expression changes', function(assert) {
+  this.set('options', {'x': [1], 'y': [2, 3]});
+  var exp = null;
+  this.set('expressionChangedBlock', (expression) => {exp=expression});
+  this.render(hbs`{{expression-builder options=options expressionChangedBlock=expressionChangedBlock}}`);
+  this.$('.block-type option[value="y"]').prop('selected', true).trigger('change');
+  assert.equal(this.$('.block-type select > option:selected').text().trim(), 'y');
+  assert.equal(exp, '[object Object]');
+});
+
+test('expressionChangedBlock fired when expression changes even if showExpression is false', function(assert) {
+  this.set('options', {'x': [1], 'y': [2, 3]});
+  var exp = null;
+  this.set('expressionChangedBlock', (expression) => {exp=expression});
+  this.render(hbs`{{expression-builder options=options expressionChangedBlock=expressionChangedBlock showExpression=false}}`);
+  this.$('.block-type option[value="y"]').prop('selected', true).trigger('change');
+  assert.equal(this.$('.block-type select > option:selected').text().trim(), 'y');
+  assert.equal(exp, '[object Object]');
+});
+
+test('expressionChangedBlock only fired when expression is something', function(assert) {
+  this.set('options', {'x': [1], 'y': [2, 3]});
+  var exp = 'previous value';
+  this.set('expressionChangedBlock', (expression) => {exp=expression});
+  this.render(hbs`{{expression-builder options=options expressionChangedBlock=expressionChangedBlock showExpression=false}}`);
   assert.equal(exp, '[object Object]');
   this.$('.block-type option[value="y"]').prop('selected', true).trigger('change');
   assert.equal(this.$('.block-type select > option:selected').text().trim(), 'y');

--- a/tests/integration/components/expression-builder-test.js
+++ b/tests/integration/components/expression-builder-test.js
@@ -144,32 +144,32 @@ test('expressionChanged only fired and returns arg1 when expression is something
 test('expressionChanged fired and returns arg2 when expression changes', function(assert) {
   this.set('options', {'x': [1], 'y': [2, 3]});
   var exp = null;
-  this.set('expressionChanged', (expression, blocks) => {exp=blocks});
+  this.set('expressionChanged', (expression, blocks) => {exp=JSON.stringify(blocks)});
   this.render(hbs`{{expression-builder options=options expressionChanged=expressionChanged}}`);
   this.$('.block-type option[value="y"]').prop('selected', true).trigger('change');
   assert.equal(this.$('.block-type select > option:selected').text().trim(), 'y');
-  assert.equal(exp, '[object Object]');
+  assert.ok(exp.indexOf('"type":"y"') >= 0);
 });
 
 test('expressionChanged fired and returns arg2 when expression changes even if showExpression is false', function(assert) {
   this.set('options', {'x': [1], 'y': [2, 3]});
   var exp = null;
-  this.set('expressionChanged', (expression, blocks) => {exp=blocks});
+  this.set('expressionChanged', (expression, blocks) => {exp=JSON.stringify(blocks)});
   this.render(hbs`{{expression-builder options=options expressionChanged=expressionChanged showExpression=false}}`);
   this.$('.block-type option[value="y"]').prop('selected', true).trigger('change');
   assert.equal(this.$('.block-type select > option:selected').text().trim(), 'y');
-  assert.equal(exp, '[object Object]');
+  assert.ok(exp.indexOf('"type":"y"') >= 0);
 });
 
 test('expressionChanged only fired and returns arg2 when expression is something', function(assert) {
   this.set('options', {'x': [1], 'y': [2, 3]});
   var exp = 'previous value';
-  this.set('expressionChanged', (expression, blocks) => {exp=blocks});
+  this.set('expressionChanged', (expression, blocks) => {exp=JSON.stringify(blocks)});
   this.render(hbs`{{expression-builder options=options expressionChanged=expressionChanged showExpression=false}}`);
   assert.equal(exp, 'previous value');
   this.$('.block-type option[value="y"]').prop('selected', true).trigger('change');
   assert.equal(this.$('.block-type select > option:selected').text().trim(), 'y');
-  assert.equal(exp, '[object Object]');
+  assert.ok(exp.indexOf('"type":"y"') >= 0);
 });
 
 test('can select a different index from the value', function(assert) {


### PR DESCRIPTION
I left the old logic there in case you want to leave it for future use. Only had to change a few tests to display [object Object] in the criterion box.

This works with my current work for [Claims Frontend](https://github.com/imtapps/claims-frontend/compare/change-ledger-mapping-codes)