### PR TITLE
Get expressionChanged to fire when deleting single block

### DIFF
--- a/addon/components/expression-builder.js
+++ b/addon/components/expression-builder.js
@@ -28,6 +28,10 @@ export default Ember.Component.extend({
       return `${type}${value}${operator}`
     })
     let exp = kv.join(' ');
+    if (blocks.length === 0) {
+      exp = '';
+    }
+    // can remove exp below and get rid of if block above, but then two tests fail
     if(exp && Ember.get(this, 'expressionChanged')) {
       Ember.get(this, 'expressionChanged')(exp, blocks);
     }

--- a/tests/integration/components/expression-builder-test.js
+++ b/tests/integration/components/expression-builder-test.js
@@ -74,6 +74,26 @@ test('can add another block', function(assert) {
   assert.equal(this.$('.expression-result').text().trim(), 'y:3 OR x:1 OR x:1');
 });
 
+test('expressionChanged fired when adding new block and removing new block', function(assert) {
+  this.set('options', {'x': [1], 'y': [2, 3]});
+  var exp = null;
+  this.set('expressionChanged', (expression) => {exp=expression});
+  this.render(hbs`{{expression-builder options=options operators=operators expressionChanged=expressionChanged}}`);
+  this.set('operators', ['OR', 'AND']);
+  assert.notOk(this.$('.block-operator').length);
+  this.$('.block-type option[value="y"]').prop('selected', true).trigger('change');
+  this.$('.block-value option[value="3"]').prop('selected', true).trigger('change');
+  assert.equal(this.$('.block-type select > option:selected').text().trim(), 'y');
+  assert.equal(this.$('.block-value select > option:selected').text().trim(), '3');
+  assert.equal(exp, 'y:3');
+  Ember.run(() => document.querySelector('.delete').click());
+  assert.equal(exp, '');
+  Ember.run(() => document.querySelector('.add').click());
+  this.$('.block-type option[value="x"]').prop('selected', true).trigger('change');
+  this.$('.block-value option[value="1"]').prop('selected', true).trigger('change');
+  assert.equal(exp, 'x:1');
+});
+
 test('can change operator block', function(assert) {
   this.set('options', {'x': [1], 'y': [2, 3]});
   this.set('operators', ['OR', 'AND']);


### PR DESCRIPTION
There is one test failing right now and a comment explaining the simplification that will cause two tests to fail. Can we delete those two tests or is that functionality required?
If we need that functionality, can we figure out a way to create an empty expression when we delete a single block? This is what we need in claims ledger mapping.